### PR TITLE
fix: Instructions modal & Header overlapping

### DIFF
--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -30,7 +30,7 @@ const props = defineProps({
   padding: 32px 25px;
   border-radius: 16px 16px 0px 0px;
   gap: 20px;
-  max-height: 90vh;
+  max-height: 90svh;
 
   .text {
     max-height: 90%;


### PR DESCRIPTION
Se aplicado, este PR corrige a sobreposição do modal de instruções ao Header da aplicação em view-ports muito pequenas.

![image](https://github.com/lhrossi/floodMap/assets/35370510/28fd337c-ccc9-4aa1-8aba-5ea04a92afde)
